### PR TITLE
fix: light theme ghost element selected contrast

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Monosami Theme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "authors": ["Samuel Onoja <0@sami.cx>", "Fabian Bergström"],
   "description": "Monosami | 98% black and white monochrome theme for Zed Editor",
   "repository": "https://github.com/borngraced/monosami"

--- a/themes/monosami.json
+++ b/themes/monosami.json
@@ -318,7 +318,7 @@
         "ghost_element.background": null,
         "ghost_element.hover": "#d4d4d4",
         "ghost_element.active": null,
-        "ghost_element.selected": "#ffffff0A",
+        "ghost_element.selected": "#d1d1d1",
         "ghost_element.disabled": null,
         "text": "#121212",
         "text.muted": "#606060",


### PR DESCRIPTION
Fixes #2 

Not much thought went into the specific shade chosen here, I don't mind the specifics so long as it's got enough contrast 😄

Before:
![image](https://github.com/borngraced/monosami/assets/32536904/ebffa819-6dd8-4ed8-bd3b-472ac1f2bc79)

After:
![image](https://github.com/borngraced/monosami/assets/32536904/8884f47a-148c-4a55-a38c-1920e57ae9c4)
